### PR TITLE
Removed -snd used in example

### DIFF
--- a/Feral Wiki/Linux Command-Line - Advanced/FileBot CLI - Basic Setup/readme.md
+++ b/Feral Wiki/Linux Command-Line - Advanced/FileBot CLI - Basic Setup/readme.md
@@ -43,7 +43,9 @@ FileBot CLI - usage
 
 Use `" "` around paths. Use `$HOME` in paths instead of `~`. Filebot gets confused about the `~`
 
-Please refer to this page: [Filebot Command Line](http://www.filebot.net/cli.html) for more options.
+Please refer to this page: [Filebot Command Line](http://www.filebot.net/cli.html) for more options. 
+
+Scripts for media center automation can be found in [this](http://www.filebot.net/forums/viewtopic.php?t=215) thread on the [Filebot forum](http://www.filebot.net/forums).
 
 
 

--- a/Feral Wiki/Linux Command-Line - Advanced/Rar and Unrar in Command Line - with Examples/readme.md
+++ b/Feral Wiki/Linux Command-Line - Advanced/Rar and Unrar in Command Line - with Examples/readme.md
@@ -58,11 +58,10 @@ This will save a significant amount of time and processing power for you and oth
 To create a rar archive with files of `200MB` and with some other compression settings (got this from a scener)
 
 ~~~
-rar a filename.rar -r -snd -m0 -vn -md4096 -ep1 -v200000000b $DIR
+rar a filename.rar -r -m0 -vn -md4096 -ep1 -v200000000b $DIR
 ~~~
 
 `-r` : Recurse subdirectories.
-`-snd`: (no idea)
 `-m0` : compression level (`0-store` / `3-default` / `5-best`)
 `-vn`: Use the old style volume naming scheme, where the first volume file in a multi-volume set has the extension .rar, following volumes are numbered from `.r00` to `.r99`.
 `-md4096` : dictionary size in Kb (`64`,`128`,`256`,`512`,`1024`,`2048`,`4097`  or `a`,`b`,`c`,`d`,`e`,`f`,`g`)


### PR DESCRIPTION
-snd enables sound in earlier versions, not used anymore as far as I can tell.

This manpage mentions -snd.
http://manpages.ubuntu.com/manpages/utopic/man1/rar.1.html