### PR TITLE
Quota from SSH accuracy improvements

### DIFF
--- a/Feral Wiki/SSH/Check your disk quota in SSH/readme.md
+++ b/Feral Wiki/SSH/Check your disk quota in SSH/readme.md
@@ -36,163 +36,163 @@ For instance, for a `Helium-4` run you would run `echo '400000' >> ~/.quotaspace
 Helium-3
 
 ~~~
-echo -n '333000' > ~/.quotaspace
+echo -n '340992' > ~/.quotaspace
 ~~~
 
 Helium-4
  
 ~~~
-echo -n '400000' > ~/.quotaspace
+echo -n '409600' > ~/.quotaspace
 ~~~
 
 Helium-5
 
 ~~~
-echo -n '500000' > ~/.quotaspace
+echo -n '512000' > ~/.quotaspace
 ~~~
 
 Helium-6
 
 ~~~
-echo -n '500000' > ~/.quotaspace
+echo -n '512000' > ~/.quotaspace
 ~~~
 
 Helium-7
 
 ~~~
-echo -n '666000' > ~/.quotaspace
+echo -n '681984' > ~/.quotaspace
 ~~~
 
 Helium-8
 
 ~~~
-echo -n '1000000' > ~/.quotaspace
+echo -n '1024000' > ~/.quotaspace
 ~~~
 
 Neon-3
 
 ~~~
-echo -n '500000' > ~/.quotaspace
+echo -n '512000' > ~/.quotaspace
 ~~~
 
 Neon-4 
 
 ~~~
-echo -n '600000' > ~/.quotaspace
+echo -n '614400' > ~/.quotaspace
 ~~~
 
 Neon-5
 
 ~~~
-echo -n '750000' > ~/.quotaspace
+echo -n '768000' > ~/.quotaspace
 ~~~
 
 Neon-6
 
 ~~~
-echo -n '750000' > ~/.quotaspace
+echo -n '768000' > ~/.quotaspace
 ~~~
 
 Neon-7
 
 ~~~
-echo -n '1000000' > ~/.quotaspace
+echo -n '1024000' > ~/.quotaspace
 ~~~
 
 Neon-8
 
 ~~~
-echo -n '1500000' > ~/.quotaspace
+echo -n '1536000' > ~/.quotaspace
 ~~~
 
 Argon-3
 
 ~~~
-echo -n '666000' > ~/.quotaspace
+echo -n '681984' > ~/.quotaspace
 ~~~
 
 Argon-4
 
 ~~~
-echo -n '800000' > ~/.quotaspace
+echo -n '819200' > ~/.quotaspace
 ~~~
 
 Argon-5
 
 ~~~
-echo -n '1000000' > ~/.quotaspace
+echo -n '1024000' > ~/.quotaspace
 ~~~
 
 Argon-6
 
 ~~~
-echo -n '1000000' > ~/.quotaspace
+echo -n '1024000' > ~/.quotaspace
 ~~~
 
 Argon-7
 
 ~~~
-echo -n '1333000' > ~/.quotaspace
+echo -n '1364992' > ~/.quotaspace
 ~~~
 
 Argon-8
 
 ~~~
-echo -n '2000000' > ~/.quotaspace
+echo -n '2048000' > ~/.quotaspace
 ~~~
 
 Xenon-3
 
 ~~~
-echo -n '1000000' > ~/.quotaspace
+echo -n '1024000' > ~/.quotaspace
 ~~~
 
 Xenon-4
 
 ~~~
-echo -n '1200000' > ~/.quotaspace
+echo -n '1228800' > ~/.quotaspace
 ~~~
 
 Xenon-5
 
 ~~~
-echo -n '1500000' > ~/.quotaspace
+echo -n '1536000' > ~/.quotaspace
 ~~~
 
 Xenon-6
 
 ~~~
-echo -n '1500000' > ~/.quotaspace
+echo -n '1536000' > ~/.quotaspace
 ~~~
 
 Xenon-7
 
 ~~~
-echo -n '2000000' > ~/.quotaspace
+echo -n '2048000' > ~/.quotaspace
 ~~~
 
 Krypton-8
 
 ~~~
-echo -n '3000000' > ~/.quotaspace
+echo -n '3072000' > ~/.quotaspace
 ~~~
 
 Radon-4
 
 ~~~
-echo -n '3000000' > ~/.quotaspace
+echo -n '3072000' > ~/.quotaspace
 ~~~
 
 Radon-7
 
 ~~~
-echo -n '5000000' > ~/.quotaspace
+echo -n '5120000' > ~/.quotaspace
 ~~~
 
 Radon-8
 
 ~~~
-echo -n '8000000' > ~/.quotaspace
+echo -n '8192000' > ~/.quotaspace
 ~~~
 
 SSD Slots
@@ -207,25 +207,25 @@ echo -n '100000' > ~/.quotaspace
 Argon
 
 ~~~
-echo -n '133000' > ~/.quotaspace
+echo -n '136192' > ~/.quotaspace
 ~~~
 
 Krypton
 
 ~~~
-echo -n '200000' > ~/.quotaspace
+echo -n '204800' > ~/.quotaspace
 ~~~
 
 Xenon
 
 ~~~
-echo -n '400000' > ~/.quotaspace
+echo -n '409600' > ~/.quotaspace
 ~~~
 
 Radon
 
 ~~~
-echo -n '800000' > ~/.quotaspace
+echo -n '819200' > ~/.quotaspace
 ~~~
 
 **Step 2:** After SSHing into your slot, run the following the commands

--- a/Feral Wiki/SSH/Check your disk quota in SSH/scripts/quota.sh
+++ b/Feral Wiki/SSH/Check your disk quota in SSH/scripts/quota.sh
@@ -2,13 +2,13 @@
 # This script outputs the available quota in a nice format.
 #
 # requirements: a file called .quotaspace in home directory
-# which contains the available diskspace in MB's, for example: 750000 for 750 GB
+# which contains the available diskspace in MB's, for example: 768000 for 750 GB (Hint, GB*1024)
 #
 # Credits:
 # Written by: mcviruss
 # Contributions:
 # https://github.com/feralhosting/feralfilehosting/pull/5
-#
+
 # Pad a string so that it is the specified number of characters long
 # adds padding to the left, default path string is a space " "
 function pad_left() {
@@ -30,38 +30,43 @@ function pad_left() {
 # Input: number which represents MB's
 # Output: formatted filesize with 2 decimals, example: 10.50 MB
 function format_filesize() {
-    if [ "$1" == "" ]; then
-            awk '{x=$1;split("MB GB TB PB",type);for(i=5;y < 1;i--) { y = x / (2^(10*i)/1.024) }; printf "%.2f %s\n",y,type[i+2]; }';
-    else
-            echo "$1" | awk '{x=$1;split("MB GB TB PB",type);for(i=5;y < 1;i--) { y = x / (2^(10*i)/1.024) }; printf "%.2f %s\n",y,type[i+2]; }';
-    fi;
+	if [ "$1" == "" ]; then
+		awk '{x=$1;split("MiB GiB TiB PiB",type);for(i=5;y < 1;i--) { y = x / (2^(10*i)) }; printf "%.2f %s\n",y,type[i+2]; }';
+	else
+		echo "$1" | awk '{x=$1;split("MiB GiB TiB PiB",type);for(i=5;y < 1;i--) { y = x / (2^(10*i)) }; printf "%.2f %s\n",y,type[i+2]; }';
+	fi;
 }
 
 # Lookup used diskspace and available diskspace
 used=$(du -s --si -B 1MB $HOME/ | cut -f 1);
 quota=$(cat ~/.quotaspace);
 available=$(echo "$quota-$used" | bc );
+exceeded=$(echo "$used-$quota" | bc );
 
 # Format results
 quota_fmt=$(echo "$quota" | format_filesize );
 used_fmt=$(echo "$used" | format_filesize );
-available_fmt=$(echo "$available" | format_filesize);
+if [ "$available" -lt "0" ]; then
+	exceeded_fmt=$(echo "$exceeded" | format_filesize );
+else
+	available_fmt=$(echo "$available" | format_filesize );
+fi;
 
 # Output results
 
 # Format header in purple with bold and underlined text
-echo -e "\033[1;35;4mDisk usage for user $(whoami)@$(hostname -f)\e[0m";
+echo -e "\033[1;35;4mDisk usage for user $(whoami)@$(hostname)\e[0m";
 
 # Format first part as bold with cyan text
-echo -e "\033[36;1mHome:\e[00m       $HOME";
-echo -e "\033[36;1mQuota:\e[00m $(pad_left "$quota_fmt" 14)";
-echo -e "\033[36;1mUsed:\e[00m $(pad_left "$used_fmt" 15)";
+echo -e "\033[36;1mHome:\e[00m         $HOME";
+echo -e "\033[36;1mQuota:\e[00m $(pad_left "$quota_fmt" 17)";
+echo -e "\033[36;1mUsed:\e[00m $(pad_left "$used_fmt" 18)";
 
 # Check if you are under or over your available diskspace
 if [ "$available" -lt "0" ]; then
 	# Format amount in red
-	echo -e "\033[36;1mAvailable:\e[00m \e[00;31m$(pad_left "$available_fmt" 10)\e[00m";
+	echo -e "\033[36;1mExceeded by:\e[00m \e[00;31m$(pad_left "$exceeded_fmt" 11)\e[00m";
 else
 	# Format amount in green
-	echo -e "\033[36;1mAvailable:\e[00m \e[00;32m$(pad_left "$available_fmt" 10)\e[00m";
+	echo -e "\033[36;1mAvailable:\e[00m \e[00;32m$(pad_left "$available_fmt" 13)\e[00m";
 fi;


### PR DESCRIPTION
I noticed that the default quota from SSH script, along with the .quotaspace specification was not reporting available space consistent with the web interface.  Where the script would tell me I had some space left, I get email notifications saying I need to free up some space, and set out to fix that.