### PR TITLE
Fix BTSync download locations

### DIFF
--- a/Feral Wiki/Software/BitTorrent Sync btsync - basic setup/scripts/install.btsync
+++ b/Feral Wiki/Software/BitTorrent Sync btsync - basic setup/scripts/install.btsync
@@ -24,9 +24,9 @@ scriptname="install.btsync"
 ###### Variable Start ######
 ############################
 #
-urlbtsync2="http://download-cdn.getsyncapp.com/stable/linux-x64/BitTorrent-Sync_x64.tar.gz"
-urlbtsync2glibc="http://download-cdn.getsyncapp.com/stable/linux-glibc-x64/BitTorrent-Sync_glibc23_x64.tar.gz"
-urlbtsync1="http://download.getsyncapp.com/endpoint/btsync/os/linux-x64/track/stable"
+urlbtsync2="http://download-cdn.getsync.com/stable/linux-x64/BitTorrent-Sync_x64.tar.gz"
+urlbtsync2glibc="http://download-cdn.getsync.com/stable/linux-glibc-x64/BitTorrent-Sync_glibc23_x64.tar.gz"
+urlbtsync1="http://download.getsync.com/endpoint/btsync/os/linux-x64/track/stable"
 #
 scripturl="https://raw.githubusercontent.com/feralhosting/feralfilehosting/master/Feral%20Wiki/Software/BitTorrent%20Sync%20btsync%20-%20basic%20setup/scripts/install.btsync"
 #


### PR DESCRIPTION
Looks like download locations are updated, getsyncapp.com 404s which breaks the script. 